### PR TITLE
Hold on api ratelimit

### DIFF
--- a/irc_bridge.py
+++ b/irc_bridge.py
@@ -343,7 +343,7 @@ class IrcHipchatBridge(protocol.ClientFactory, HipChatMixin):
         # room and sends them as a single hipchat "message"
         # or that's the theory at least
         todo = {}
-        if not (self.stats.ratelimit_remaining == 0 and self.stats.ratelimit_reset > time.time()):
+        if not (self.stats.ratelimit_remaining == '0' and int(self.stats.ratelimit_reset) > int(time.time())):
             while not self.irc_to_hipchat_queue.empty():
                 m = self.irc_to_hipchat_queue.get()
                 if "topic" in m:
@@ -373,9 +373,9 @@ class IrcHipchatBridge(protocol.ClientFactory, HipChatMixin):
                     try:
                         response = self.local_send_room_message(channel, txt_message, html=False, notify=True)
                         try:
-                            self.stats.ratelimit_remaining = response.headers['x-ratelimit-remaining']
-                            self.stats.ratelimit_limit = response.headers['x-ratelimit-limit']
-                            self.stats.ratelimit_reset = response.headers['x-ratelimit-reset']
+                            self.stats.ratelimit_remaining = response.headers.get('x-ratelimit-remaining', 0) # Default to 0 remaining if we hit an issue w/ ratelimit headers
+                            self.stats.ratelimit_limit = response.headers.get('x-ratelimit-limit', self.stats.ratelimit_limit)
+                            self.stats.ratelimit_reset = response.headers.get('x-ratelimit-reset', self.stats.ratelimit_reset)
                             self.stats.hipchat_api_count += 1
                             self.stats.channels[('#' + channel).lower()].hipchat_api_count += 1
                         except KeyError, e:


### PR DESCRIPTION
* Keeps messages from irc->hipchat in the queue while we've hit the Hipchat API rate limit
 * We may still lose some messages, as occasionally hipchat apparently sends '60' for x-ratelimit-reset rather than a valid timestamp while we've hit the limit. This does not solve for that problem yet; we can check for the 429 error and requeue later.
* Also catches an issue where  hipchat sometimes doesn't actually send the 'x-ratelimit-limit' header which was causing an issue saving stats when relaying.  Now we default to the last known values for all ratelimit stats, except for ratelimit_remaining. If we hit an issue with this one, we set to 0 to pause relaying until ratelimit_reset.
